### PR TITLE
Fix GPU part_number data formatting

### DIFF
--- a/open-db/GPU/00034350-61f0-4057-ad9d-9aaea84645d0.json
+++ b/open-db/GPU/00034350-61f0-4057-ad9d-9aaea84645d0.json
@@ -10,7 +10,9 @@
     "name": "Asus ROG STRIX Radeon RX 570 4GB GDDR5 Black",
     "manufacturer": "Asus",
     "part_numbers": [
-      "ROG-STRIX-RX570-O4G-GAMING                                                    STRIX-RX570-O4G-GAMING                                                    90YV0AJ0-M0NA00"
+      "ROG-STRIX-RX570-O4G-GAMING",
+      "STRIX-RX570-O4G-GAMING",
+      "90YV0AJ0-M0NA00"
     ],
     "series": "Radeon RX 570",
     "variant": "Asus"
@@ -38,8 +40,7 @@
     "displayport_2_1a": 0,
     "displayport_1_4a": 1,
     "dvi_d": 0,
-    "vga": 0,
-    "_id": "67f9c61b865ad0c3553ea336"
+    "vga": 0
   },
   "general_product_information": {}
 }

--- a/open-db/GPU/001f4618-d3f8-44d7-8c6f-697bfbdc1858.json
+++ b/open-db/GPU/001f4618-d3f8-44d7-8c6f-697bfbdc1858.json
@@ -10,7 +10,8 @@
     "name": "MSI VENTUS 2X OC GeForce RTX 4070 12GB GDDR6 White / Silver",
     "manufacturer": "MSI",
     "part_numbers": [
-      "RTX 4070 VENTUS 2X WHITE 12G OCGeForce RTX 4070 VENTUS 2X WHITE 12G OCV513-403R"
+      "RTX 4070 VENTUS 2X WHITE 12G OC",
+      "V513-403R"
     ],
     "series": "GeForce RTX 4070",
     "variant": "MSI"
@@ -39,8 +40,7 @@
     "displayport_2_1a": 0,
     "displayport_1_4a": 3,
     "dvi_d": 0,
-    "vga": 0,
-    "_id": "67f9c7c1865ad0c3553ebda2"
+    "vga": 0
   },
   "core_count": 5888,
   "general_product_information": {

--- a/open-db/GPU/242e1d17-f510-47dc-a4a3-794a3895eccd.json
+++ b/open-db/GPU/242e1d17-f510-47dc-a4a3-794a3895eccd.json
@@ -10,7 +10,8 @@
     "name": "Asus STRIX Radeon RX 560 - 1024 4GB GDDR5 Black",
     "manufacturer": "Asus",
     "part_numbers": [
-      "ROG-STRIX-RX560-O4G-GAMING                                                    90YV0AH0-M0NA00"
+      "ROG-STRIX-RX560-O4G-GAMING",
+      "90YV0AH0-M0NA00"
     ],
     "series": "Radeon RX 560 - 1024",
     "variant": "Asus"
@@ -38,8 +39,7 @@
     "displayport_2_1a": 0,
     "displayport_1_4a": 1,
     "dvi_d": 0,
-    "vga": 0,
-    "_id": "67f9c57c865ad0c3553e9933"
+    "vga": 0
   },
   "core_count": 0,
   "general_product_information": {}

--- a/open-db/GPU/7ff24e3c-ca88-4b52-a9c2-4e3db5607bd6.json
+++ b/open-db/GPU/7ff24e3c-ca88-4b52-a9c2-4e3db5607bd6.json
@@ -10,7 +10,8 @@
     "name": "Asus TUF GAMING OC Radeon RX 6500 XT 4GB GDDR6 Black",
     "manufacturer": "Asus",
     "part_numbers": [
-      "TUF-RX6500XT-O4G-GAMING                                                    90YV0HA0-M0NA00"
+      "TUF-RX6500XT-O4G-GAMING",
+      "90YV0HA0-M0NA00"
     ],
     "series": "Radeon RX 6500 XT",
     "variant": "Asus"
@@ -38,8 +39,7 @@
     "displayport_2_1a": 0,
     "displayport_1_4a": 1,
     "dvi_d": 0,
-    "vga": 0,
-    "_id": "67f9c5ee865ad0c3553ea047"
+    "vga": 0
   },
   "core_count": 1024,
   "general_product_information": {

--- a/open-db/GPU/86b5f72d-5d31-4be6-a684-b3737e75a660.json
+++ b/open-db/GPU/86b5f72d-5d31-4be6-a684-b3737e75a660.json
@@ -10,7 +10,8 @@
     "name": "Asus STRIX GAMING OC GeForce GTX 1650 G5 4GB GDDR5 Black",
     "manufacturer": "Asus",
     "part_numbers": [
-      "ROG-STRIX-GTX1650-O4G-GAMING                                                    90YV0CX1-M0NA00"
+      "ROG-STRIX-GTX1650-O4G-GAMING",
+      "90YV0CX1-M0NA00"
     ],
     "series": "GeForce GTX 1650 G5",
     "variant": "Asus"
@@ -38,8 +39,7 @@
     "displayport_2_1a": 0,
     "displayport_1_4a": 2,
     "dvi_d": 0,
-    "vga": 0,
-    "_id": "67f9c597865ad0c3553e9ace"
+    "vga": 0
   },
   "core_count": 0,
   "general_product_information": {

--- a/open-db/GPU/912b1323-4ce2-4c6b-bb96-91a6e7e2c725.json
+++ b/open-db/GPU/912b1323-4ce2-4c6b-bb96-91a6e7e2c725.json
@@ -10,7 +10,8 @@
     "name": "Asus DUAL MINI OC GeForce GTX 1660 SUPER 6GB GDDR6 Black",
     "manufacturer": "Asus",
     "part_numbers": [
-      "DUAL-GTX1660S-O6G-MINI                                                    90YV0DT4-M0NA00"
+      "DUAL-GTX1660S-O6G-MINI",
+      "90YV0DT4-M0NA00"
     ],
     "series": "GeForce GTX 1660 SUPER",
     "variant": "Asus"
@@ -38,8 +39,7 @@
     "displayport_2_1a": 0,
     "displayport_1_4a": 1,
     "dvi_d": 0,
-    "vga": 0,
-    "_id": "67f9c5cf865ad0c3553e9e54"
+    "vga": 0
   },
   "general_product_information": {}
 }

--- a/open-db/GPU/95332c26-8bac-4685-83b5-4c924b28f70e.json
+++ b/open-db/GPU/95332c26-8bac-4685-83b5-4c924b28f70e.json
@@ -10,7 +10,8 @@
     "name": "Asus TUF GAMING OC GeForce GTX 1650 SUPER 4GB GDDR6 Black",
     "manufacturer": "Asus",
     "part_numbers": [
-      "TUF-GTX1650S-O4G-GAMING                                                    90YV0E42-M0NA00"
+      "TUF-GTX1650S-O4G-GAMING",
+      "90YV0E42-M0NA00"
     ],
     "series": "GeForce GTX 1650 SUPER",
     "variant": "Asus"
@@ -38,8 +39,7 @@
     "displayport_2_1a": 0,
     "displayport_1_4a": 1,
     "dvi_d": 0,
-    "vga": 0,
-    "_id": "67f9c50c865ad0c3553e924c"
+    "vga": 0
   },
   "general_product_information": {
     "amazon_sku": "B081KY5L57",

--- a/open-db/GPU/a6c6d8b9-d014-4f88-8dfd-0c7b75dbca6d.json
+++ b/open-db/GPU/a6c6d8b9-d014-4f88-8dfd-0c7b75dbca6d.json
@@ -10,7 +10,8 @@
     "name": "Asus STRIX GeForce GTX 1050 Ti 4GB GDDR5 Black",
     "manufacturer": "Asus",
     "part_numbers": [
-      "STRIX-GTX1050TI-O4G-GAMING                                                    90YV0A30-M0NA00"
+      "STRIX-GTX1050TI-O4G-GAMING",
+      "90YV0A30-M0NA00"
     ],
     "series": "GeForce GTX 1050 Ti",
     "variant": "Asus"
@@ -38,8 +39,7 @@
     "displayport_2_1a": 0,
     "displayport_1_4a": 1,
     "dvi_d": 0,
-    "vga": 0,
-    "_id": "67f9c60f865ad0c3553ea268"
+    "vga": 0
   },
   "general_product_information": {}
 }


### PR DESCRIPTION
## Summary
- clean up GPU JSON entries with malformed part_numbers
- remove leftover `_id` fields from those files

## Testing
- `ajv validate -s schemas/GPU.schema.json -d open-db/GPU/00034350-61f0-4057-ad9d-9aaea84645d0.json`
- `ajv validate -s schemas/GPU.schema.json -d open-db/GPU/001f4618-d3f8-44d7-8c6f-697bfbdc1858.json`
- `ajv validate -s schemas/GPU.schema.json -d open-db/GPU/242e1d17-f510-47dc-a4a3-794a3895eccd.json`
- `ajv validate -s schemas/GPU.schema.json -d open-db/GPU/7ff24e3c-ca88-4b52-a9c2-4e3db5607bd6.json`
- `ajv validate -s schemas/GPU.schema.json -d open-db/GPU/86b5f72d-5d31-4be6-a684-b3737e75a660.json`
- `ajv validate -s schemas/GPU.schema.json -d open-db/GPU/912b1323-4ce2-4c6b-bb96-91a6e7e2c725.json`
- `ajv validate -s schemas/GPU.schema.json -d open-db/GPU/95332c26-8bac-4685-83b5-4c924b28f70e.json`
- `ajv validate -s schemas/GPU.schema.json -d open-db/GPU/a6c6d8b9-d014-4f88-8dfd-0c7b75dbca6d.json`


------
https://chatgpt.com/codex/tasks/task_b_684d82bdb05083338a2d37499996c234