### PR TITLE
docs: add local validation guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,20 @@ Thank you for your interest in contributing to BuildCores OpenDB! This document 
 
 ### Local Validation
 
-TODO
+Before opening a pull request you can verify your JSON files locally using
+[ajv-cli](https://github.com/ajv-validator/ajv-cli):
+
+```bash
+npm install -g ajv-cli
+```
+
+Run `ajv validate` with the appropriate schema for each category. For example:
+
+```bash
+ajv validate -s schemas/CPU.schema.json -d open-db/CPU/*.json
+```
+
+Replace `CPU` with the folder for the component type you are validating.
 
 ### PR Validation
 


### PR DESCRIPTION
## Summary
- update Local Validation section in CONTRIBUTING

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684d845c3dc48333a9817c471844d211