### PR TITLE
Add schema compilation check

### DIFF
--- a/.github/workflows/pr_validation.yaml
+++ b/.github/workflows/pr_validation.yaml
@@ -26,6 +26,17 @@ jobs:
         run: |
           npm install -g ajv-cli@5.0.0
 
+      - name: Compile JSON schemas
+        run: |
+          set -e
+          for schema in schemas/*.schema.json; do
+            echo "Compiling $schema"
+            if ! ajv compile -s "$schema"; then
+              echo "::error file=$schema::Schema failed to compile"
+              exit 1
+            fi
+          done
+
       - name: Get changed JSON files
         id: changed-files
         run: |


### PR DESCRIPTION
## Summary
- validate that every schema in `schemas/` compiles

## Testing
- `npm install -g ajv-cli@5.0.0`
- `for f in schemas/*.schema.json; do ajv compile -s "$f" >/tmp/c.log || { echo fail $f; break; }; done`

------
https://chatgpt.com/codex/tasks/task_b_684d845cc0188333b51b861e139c15aa