### PR TITLE
Add local validation instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,29 @@ Thank you for your interest in contributing to BuildCores OpenDB! This document 
 
 ### Local Validation
 
-TODO
+Before opening a pull request, you can validate your JSON files locally. This
+repository uses [`ajv-cli`](https://github.com/ajv-validator/ajv-cli) for schema
+validation.
+
+1. **Install Node.js and npm** if you don't already have them. Any recent LTS
+   version (16 or newer) works.
+2. **Install ajv-cli** globally (or use it via `npx`):
+   ```bash
+   npm install -g ajv-cli
+   ```
+3. **Run validation**. Point `ajv` to the appropriate schema and data files. For
+   example, to validate all CPU JSON files:
+   ```bash
+   ajv validate -s schemas/CPU.schema.json -d open-db/CPU/*.json --all-errors
+   ```
+   Replace `CPU` with other categories as needed, or provide a specific file
+   path:
+   ```bash
+   ajv validate -s schemas/<category>.schema.json -d open-db/<category>/<file>.json --all-errors
+   ```
+4. Ensure the filename matches the `opendb_id` field inside each JSON file.
+
+Fix any validation errors before submitting your PR.
 
 ### PR Validation
 


### PR DESCRIPTION
## Summary
- expand `CONTRIBUTING.md` Local Validation section
- show how to install and run `ajv-cli` to validate schema

## Testing
- `node -v`
- `npm -v`
- `ajv -h`
- `ajv validate -s schemas/CPU.schema.json -d "open-db/CPU/*.json" --all-errors | head`


------
https://chatgpt.com/codex/tasks/task_b_684d84a5da8883338ee2a6eb4d197dfb