### PR TITLE
Add Three.js configurator sample

### DIFF
--- a/samples/threejs-configurator/README.md
+++ b/samples/threejs-configurator/README.md
@@ -1,0 +1,15 @@
+# Three.js Configurator Sample
+
+This example demonstrates how a simple configurator could load and display 3D component models with [Three.js](https://threejs.org/).
+
+## Running the Example
+
+1. Start a local HTTP server in this directory. You can use Python's built-in server:
+
+```bash
+python3 -m http.server 8000
+```
+
+2. Open your browser and navigate to `http://localhost:8000/index.html`.
+
+The page will load a couple of low-poly models from the public Three.js examples and display them with orbit controls.

--- a/samples/threejs-configurator/index.html
+++ b/samples/threejs-configurator/index.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Three.js Configurator Sample</title>
+  <style>
+    body { margin: 0; overflow: hidden; }
+    canvas { display: block; }
+  </style>
+</head>
+<body>
+<script src="https://unpkg.com/three/build/three.min.js"></script>
+<script type="module">
+import { OrbitControls } from 'https://unpkg.com/three/examples/jsm/controls/OrbitControls.js';
+import { GLTFLoader } from 'https://unpkg.com/three/examples/jsm/loaders/GLTFLoader.js';
+
+const scene = new THREE.Scene();
+scene.background = new THREE.Color(0xeeeeee);
+
+const camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 1000);
+camera.position.set(0, 1, 3);
+
+const renderer = new THREE.WebGLRenderer({ antialias: true });
+renderer.setSize(window.innerWidth, window.innerHeight);
+document.body.appendChild(renderer.domElement);
+
+const controls = new OrbitControls(camera, renderer.domElement);
+controls.target.set(0, 1, 0);
+controls.update();
+
+const light1 = new THREE.AmbientLight(0xffffff, 0.6);
+scene.add(light1);
+const light2 = new THREE.DirectionalLight(0xffffff, 0.6);
+light2.position.set(2, 5, 3);
+scene.add(light2);
+
+const loader = new GLTFLoader();
+const models = [
+  'https://threejs.org/examples/models/gltf/DamagedHelmet/glTF/DamagedHelmet.gltf',
+  'https://threejs.org/examples/models/gltf/Flamingo.glb'
+];
+
+models.forEach((url, index) => {
+  loader.load(url, (gltf) => {
+    const model = gltf.scene;
+    model.position.x = index * 1.5 - 0.75; // spread models a bit
+    scene.add(model);
+  }, undefined, (err) => {
+    console.error('Error loading model:', err);
+  });
+});
+
+window.addEventListener('resize', onWindowResize);
+function onWindowResize() {
+  camera.aspect = window.innerWidth / window.innerHeight;
+  camera.updateProjectionMatrix();
+  renderer.setSize(window.innerWidth, window.innerHeight);
+}
+
+function animate() {
+  requestAnimationFrame(animate);
+  renderer.render(scene, camera);
+}
+animate();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `samples/threejs-configurator` with a small example
- example loads two remote glTF models via Three.js
- document running the sample with `python3 -m http.server`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684d84a75a508333afff2f7e75818016