### PR TITLE
Add three.js PC case viewer sample

### DIFF
--- a/samples/pc-case-viewer/README.md
+++ b/samples/pc-case-viewer/README.md
@@ -1,0 +1,16 @@
+# PC Case Viewer Sample
+
+This sample demonstrates how to load case data from the OpenDB and visualize
+the case dimensions using [Three.js](https://threejs.org/).
+
+## Running the Example
+
+1. Start a local HTTP server in this directory (for example with Python):
+   ```bash
+   python3 -m http.server 8000
+   ```
+2. Open your browser at `http://localhost:8000/index.html`.
+
+Use the dropdown to select a PC case. The viewer displays a simple 3D box
+representing the case's dimensions.
+

--- a/samples/pc-case-viewer/index.html
+++ b/samples/pc-case-viewer/index.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>PC Case Viewer</title>
+  <style>
+    body { margin: 0; display: flex; flex-direction: column; height: 100vh; }
+    #viewer { flex: 1; }
+    canvas { display: block; }
+    #controls { padding: 8px; background: #f0f0f0; }
+  </style>
+</head>
+<body>
+<div id="controls">
+  <label for="caseSelect">Select PC Case:</label>
+  <select id="caseSelect"></select>
+</div>
+<div id="viewer"></div>
+
+<script src="https://unpkg.com/three/build/three.min.js"></script>
+<script type="module">
+import { OrbitControls } from 'https://unpkg.com/three/examples/jsm/controls/OrbitControls.js';
+
+const cases = [
+  {
+    name: 'Fractal Design Meshify C',
+    path: '../../open-db/PCCase/0000caee-142c-48f6-99be-9c6f4dd18845.json'
+  },
+  {
+    name: 'Fractal Design North',
+    path: '../../open-db/PCCase/000a0d8c-7590-4fd6-a724-41c36a3a4a9f.json'
+  }
+];
+
+const select = document.getElementById('caseSelect');
+cases.forEach((c, i) => {
+  const opt = document.createElement('option');
+  opt.value = i;
+  opt.textContent = c.name;
+  select.appendChild(opt);
+});
+
+let scene, camera, renderer, controls, box;
+
+function initViewer() {
+  scene = new THREE.Scene();
+  scene.background = new THREE.Color(0xeeeeee);
+
+  camera = new THREE.PerspectiveCamera(60, viewer.clientWidth / viewer.clientHeight, 0.1, 1000);
+  camera.position.set(0, 150, 200);
+
+  renderer = new THREE.WebGLRenderer({ antialias: true });
+  renderer.setSize(viewer.clientWidth, viewer.clientHeight);
+  viewer.appendChild(renderer.domElement);
+
+  controls = new OrbitControls(camera, renderer.domElement);
+  controls.target.set(0, 80, 0);
+  controls.update();
+
+  const ambient = new THREE.AmbientLight(0xffffff, 0.6);
+  scene.add(ambient);
+  const dir = new THREE.DirectionalLight(0xffffff, 0.6);
+  dir.position.set(50, 100, 70);
+  scene.add(dir);
+
+  window.addEventListener('resize', onWindowResize);
+  animate();
+}
+
+function onWindowResize() {
+  camera.aspect = viewer.clientWidth / viewer.clientHeight;
+  camera.updateProjectionMatrix();
+  renderer.setSize(viewer.clientWidth, viewer.clientHeight);
+}
+
+function animate() {
+  requestAnimationFrame(animate);
+  renderer.render(scene, camera);
+}
+
+async function loadCase(index) {
+  const res = await fetch(cases[index].path);
+  const data = await res.json();
+  const dims = parseDimensions(data.dimensions);
+  updateBox(dims);
+}
+
+function parseDimensions(text) {
+  if (!text) return { w: 100, h: 100, d: 100 };
+  const parts = text.split(/x/i).map(s => parseFloat(s.trim()));
+  return { d: parts[0] || 100, w: parts[1] || 100, h: parts[2] || 100 };
+}
+
+function updateBox({w, h, d}) {
+  if (box) scene.remove(box);
+  const geom = new THREE.BoxGeometry(w, h, d);
+  const material = new THREE.MeshStandardMaterial({ color: 0x6699ff, transparent: true, opacity: 0.6 });
+  box = new THREE.Mesh(geom, material);
+  scene.add(box);
+}
+
+select.addEventListener('change', (e) => loadCase(e.target.value));
+
+initViewer();
+loadCase(0);
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a `pc-case-viewer` example to demonstrate loading case data
- visualize dimensions using Three.js

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684d865300548333ad89854b6d1e0b82